### PR TITLE
Add: Eleventy GitHub Actions workflow

### DIFF
--- a/.github/eleventy.yml
+++ b/.github/eleventy.yml
@@ -1,0 +1,16 @@
+name: Eleventy
+on: [push]
+
+jobs:
+  build_deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Build
+        uses: TartanLlama/actions-eleventy@master
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: _site 
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR will enable me to do the first phase which is to test to see if I can get Eleventy to be built on GitHub Pages instead of Netlify.