### PR TITLE
Update: Add notes to have postsByYear functionality

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,6 +20,24 @@ module.exports = (config) => {
 		words:
 			'simply,obviously,basically,of course,clearly,just,everyone knows,however,easy',
 	});
+
+	// group intermittent notes by years
+	config.addCollection('postsByYear', (collection) => {
+		const posts = collection.getFilteredByTag('notes').reverse();
+		const years = posts.map((post) => post.date.getFullYear());
+		const uniqueYears = [...new Set(years)];
+
+		const postsByYear = uniqueYears.reduce((prev, year) => {
+			const filteredPosts = posts.filter(
+				(post) => post.date.getFullYear() === year,
+			);
+
+			return [...prev, [year, filteredPosts]];
+		}, []);
+
+		return postsByYear;
+	});
+
 	config.addPlugin(pluginRss);
 	config.addNunjucksShortcode('siteName', siteName);
 

--- a/_includes/blocks/notes.njk
+++ b/_includes/blocks/notes.njk
@@ -1,7 +1,15 @@
-<ul>
-{%- for note in collections.notes | reverse -%}
-	<li><a href="{{ note.url | url }}" title="{{ note.data.title }}">{{ note.data.title }}</a> &ndash; {{ note.data.date.toDateString('en-GB') }}</li>
-{%- endfor -%}
-</ul>
+{% for year, yearPosts in collections.postsByYear %}
+	<h2>{{ year }}</h2>
+	<ul>
+		{% for post in yearPosts | reverse %}
+		<li>
+			<a href="{{ post.url | url }}" title="{{ post.data.title }}">
+				{{ post.data.title }}
+			</a>
+			&ndash; {{ post.data.date.toDateString('en-GB') }}
+		</li>
+		{% endfor %}
+	</ul>
+{% endfor %}
 
 <small><a href="https://jamesloveridge.dev/notes-feed.xml" title="Subscribe to the RSS feed if you dare to…">RSS feed</a></small>

--- a/notes/index.md
+++ b/notes/index.md
@@ -2,6 +2,4 @@
 layout: archive-notes.njk
 title: A collection of notes
 ---
-# Notes
-
-## 2020
+# Intermittent notes


### PR DESCRIPTION
For a long time I've always wanted to group my intermittent notes by year so that I could then do some fancy styling later down the line.

I came across this good solution and implemented it.

https://github.com/11ty/eleventy/issues/1284#issuecomment-1026679407