### PR TITLE
chore: use actions/upload-pages-artifact@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       # Only deploy on push to main
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `upload-pages-artifact` action. This is a small change that helps keep the workflow up-to-date and may include improvements or bug fixes from the newer version.