### PR TITLE
chore: add configure-pages@v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,10 @@ jobs:
         run: npm run build
 
       # Only deploy on push to main
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+
       - name: Upload Pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v2
@@ -48,6 +52,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: deployment
         uses: actions/deploy-pages@v4
-        # environment:
-        #   name: github-pages
-        #   url: ${{ steps.deployment.outputs.page_url }}
+        environment:
+          name: github-pages
+          url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and deploying the project, specifically improving the deployment process to GitHub Pages. The main changes ensure that the deployment steps are properly configured and that the environment details are set for deployments to the `main` branch.

Deployment workflow improvements:

* Added a new step to configure GitHub Pages using `actions/configure-pages@v5`, which runs only on pushes to the `main` branch.
* Enabled and uncommented the environment configuration for the deployment step, setting the environment name to `github-pages` and using the deployment output URL.