### PR TITLE
fix: add padding to section bottom

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -48,6 +48,10 @@ img {
 	width: 100%;
 }
 
+section {
+	padding: 0 0 2rem;
+}
+
 footer {
 	padding: 2rem 0;
 }


### PR DESCRIPTION
This pull request introduces a small styling update to the base CSS. The main change is the addition of padding to all `section` elements.

* Added `padding: 0 0 2rem;` to the `section` selector in `src/styles/base.css` to provide extra space at the bottom of sections.